### PR TITLE
config example file: Variable is called private_zones and not privat_…

### DIFF
--- a/openvpn-ddns.json.example
+++ b/openvpn-ddns.json.example
@@ -10,6 +10,6 @@
     "public_search_domain": "hosts.domain.tld",
     "public_zones": [ "no-ip.domain.tld" ],
     "private_search_domain": "hosts2.domain.tld",
-    "privat_zones": [ "vpn.domain.tld" ]
+    "private_zones": [ "vpn.domain.tld" ]
   }
 }


### PR DESCRIPTION
…zones (typo)